### PR TITLE
Add deep link to set API URL

### DIFF
--- a/app/set-url/index.tsx
+++ b/app/set-url/index.tsx
@@ -9,7 +9,10 @@ export default function SetUrlPage() {
 
   if (params.u && typeof params.u === "string") {
     setUrlPrefix(params.u);
-    Alert.alert("API URL updated", "You can view this or reset to production in settings.");
+    Alert.alert(
+      "API URL updated",
+      "You can view this or reset to production in settings.",
+    );
   }
 
   router.back();

--- a/app/set-url/index.tsx
+++ b/app/set-url/index.tsx
@@ -1,0 +1,16 @@
+import { useGlobalSearchParams, useRouter } from "expo-router";
+import { useUrlPrefix } from "../../lib/lovatAPI/lovatAPI";
+import { Alert } from "react-native";
+
+export default function SetUrlPage() {
+  const params = useGlobalSearchParams();
+  const setUrlPrefix = useUrlPrefix((state) => state.setUrlPrefix);
+  const router = useRouter();
+
+  if (params.u && typeof params.u === "string") {
+    setUrlPrefix(params.u);
+    Alert.alert("API URL updated", "You can view this or reset to production in settings.");
+  }
+
+  router.back();
+}

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -266,8 +266,6 @@ const CustomAPIUrlEditor = () => {
   const prefixIsCustom = useUrlPrefix((state) => state.getIsCustom());
   const setUrlPrefix = useUrlPrefix((state) => state.setUrlPrefix);
 
-  console.log({ prefixIsCustom });
-
   if (!prefixIsCustom) {
     return null;
   }

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -266,7 +266,7 @@ const CustomAPIUrlEditor = () => {
   const prefixIsCustom = useUrlPrefix((state) => state.getIsCustom());
   const setUrlPrefix = useUrlPrefix((state) => state.setUrlPrefix);
 
-  console.log({ prefixIsCustom })
+  console.log({ prefixIsCustom });
 
   if (!prefixIsCustom) {
     return null;
@@ -302,11 +302,9 @@ const CustomAPIUrlEditor = () => {
               {useUrlPrefix.getState().getUrlPrefix()}
             </BodyMedium>
           </View>
-          <Button onPress={() => setUrlPrefix(null)}>
-            Reset
-          </Button>
+          <Button onPress={() => setUrlPrefix(null)}>Reset</Button>
         </View>
       </View>
     </View>
   );
-}
+};

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -31,6 +31,7 @@ import { useQrCodeSizeStore } from "../../lib/storage/userStores";
 import { Icon } from "../../lib/components/Icon";
 import { useTrainingModeStore } from "../../lib/storage/userStores";
 import React from "react";
+import { useUrlPrefix } from "../../lib/lovatAPI/lovatAPI";
 
 export default function Settings() {
   return (
@@ -72,6 +73,7 @@ export default function Settings() {
               <TournamentSelector />
               <TrainingModeSelector />
               <QRCodeSizeLink />
+              <CustomAPIUrlEditor />
               <View
                 style={{
                   marginTop: 50,
@@ -259,3 +261,52 @@ const TournamentSelector = () => {
     </View>
   );
 };
+
+const CustomAPIUrlEditor = () => {
+  const prefixIsCustom = useUrlPrefix((state) => state.getIsCustom());
+  const setUrlPrefix = useUrlPrefix((state) => state.setUrlPrefix);
+
+  console.log({ prefixIsCustom })
+
+  if (!prefixIsCustom) {
+    return null;
+  }
+
+  return (
+    <View>
+      <Heading1Small>Custom API URL</Heading1Small>
+      <View
+        style={{
+          marginTop: 7,
+          padding: 7,
+          borderRadius: 10,
+          backgroundColor: colors.secondaryContainer.default,
+          gap: 7,
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 7,
+          }}
+        >
+          <View
+            style={{
+              padding: 7,
+              flex: 1,
+            }}
+          >
+            <BodyMedium numberOfLines={1}>
+              {useUrlPrefix.getState().getUrlPrefix()}
+            </BodyMedium>
+          </View>
+          <Button onPress={() => setUrlPrefix(null)}>
+            Reset
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/lib/components/text/BodyMedium.tsx
+++ b/lib/components/text/BodyMedium.tsx
@@ -1,20 +1,28 @@
 import { Text } from "react-native";
 import { colors } from "../../colors";
+import React from "react";
 
 const BodyMedium = ({
   children,
   color,
+  style,
+  ...props
 }: {
   children: React.ReactNode;
   color?: string;
-}) => {
+  style?: React.ComponentProps<typeof Text>["style"];
+} & React.ComponentProps<typeof Text>) => {
   return (
     <Text
-      style={{
-        fontFamily: "Heebo_400Regular",
-        fontSize: 14,
-        color: color ?? colors.body.default,
-      }}
+      style={[
+        {
+          fontFamily: "Heebo_400Regular",
+          fontSize: 14,
+          color: color ?? colors.body.default,
+        },
+        style,
+      ]}
+      {...props}
     >
       {children}
     </Text>

--- a/lib/lovatAPI/lovatAPI.ts
+++ b/lib/lovatAPI/lovatAPI.ts
@@ -1,11 +1,33 @@
+import { create } from "zustand";
 import { useTeamStore } from "../storage/userStores";
+import { persist } from "zustand/middleware";
+import { storage } from "../storage/zustandStorage";
 
-const urlPrefix = process.env.EXPO_PUBLIC_API_URL;
+const defaultUrlPrefix = process.env.EXPO_PUBLIC_API_URL;
+
+export const useUrlPrefix = create(
+  persist<{
+    urlPrefix: string | null;
+    setUrlPrefix: (urlPrefix: string | null) => void;
+    getUrlPrefix: () => string;
+    getIsCustom: () => boolean;
+  }>(
+    (set, get) => ({
+      urlPrefix: null,
+      setUrlPrefix: (urlPrefix) => {
+        set({ urlPrefix });
+      },
+      getUrlPrefix: () => get().urlPrefix ?? defaultUrlPrefix!,
+      getIsCustom: () => get().urlPrefix !== null,
+    }),
+    { name: "urlPrefix", storage },
+  ),
+);
 
 export const get = async (url: string) => {
   const teamCode = useTeamStore.getState().code;
 
-  return await fetch(urlPrefix + url, {
+  return await fetch(useUrlPrefix.getState().getUrlPrefix() + url, {
     headers: {
       method: "GET",
       "X-Team-Code": teamCode ?? "",
@@ -16,7 +38,7 @@ export const get = async (url: string) => {
 export const post = async (url: string, body: unknown) => {
   const teamCode = useTeamStore.getState().code;
 
-  return await fetch(urlPrefix + url, {
+  return await fetch(useUrlPrefix.getState().getUrlPrefix() + url, {
     method: "POST",
     body: JSON.stringify(body),
     headers: {
@@ -29,7 +51,7 @@ export const post = async (url: string, body: unknown) => {
 export const put = async (url: string, body: unknown) => {
   const teamCode = useTeamStore.getState().code;
 
-  return await fetch(urlPrefix + url, {
+  return await fetch(useUrlPrefix.getState().getUrlPrefix() + url, {
     method: "PUT",
     body: JSON.stringify(body),
     headers: {
@@ -42,7 +64,7 @@ export const put = async (url: string, body: unknown) => {
 export const del = async (url: string) => {
   const teamCode = useTeamStore.getState().code;
 
-  return await fetch(urlPrefix + url, {
+  return await fetch(useUrlPrefix.getState().getUrlPrefix() + url, {
     method: "DELETE",
     headers: {
       "X-Team-Code": teamCode ?? "",


### PR DESCRIPTION
The idea is that while working on server/analysis code, it would be nice for our developers to be able to test out their code on the actual app rather than a generic HTTP client.

In practice, the app detects when the user's device opens the URI `com.frc.lovatcollection://set-url?u=<url>` and sets it to that. Our developers will be able to do this easily by scanning QR codes displayed in their terminal in development mode.

Here's an example of a QR code that sets the API URL prefix to `http://collins-macbook-pro.local:3000` using the deep link `com.frc8033.lovatcollection://set-url?u=http%3A%2F%2Fcollins-macbook-pro.local%3A3000`:

![QR Code Barcode](https://github.com/user-attachments/assets/bcc528e3-9cc1-4da4-8de3-1184bebe7721)

Once done developers can reset the prefix to whatever the environment variable is set to in settings.