### PR TITLE
Custom fields in the post-match screen

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Collection",
     "slug": "lovat-collection",
-    "version": "26.0.5",
+    "version": "26.0.6",
     "orientation": "portrait",
     "userInterfaceStyle": "dark",
     "splash": {

--- a/app/game/post-match.tsx
+++ b/app/game/post-match.tsx
@@ -615,6 +615,7 @@ const CustomFieldSelector = ({
       <LabelSmall>{title}</LabelSmall>
       <Picker
         style="inset-picker"
+        contained={false}
         options={options.map((option) => ({
           label: option,
           value: option,

--- a/app/game/post-match.tsx
+++ b/app/game/post-match.tsx
@@ -355,7 +355,12 @@ export default function PostMatch() {
           </View>
           {reportState.customFields.length > 0 && (
             <View style={{ gap: 14, marginBottom: 18 }}>
-              <LabeledDivider label="Asked by your team" />
+              {/* Center the divider between the Notes block above (which adds
+                  its own 18px bottom margin on top of the 14px column gap) and
+                  the fields below (14px column gap). */}
+              <View style={{ marginBottom: 18 }}>
+                <LabeledDivider label="Asked by your team" />
+              </View>
               {reportState.customFields.map((field) => (
                 <CustomFieldInput
                   key={field.uuid}

--- a/app/game/post-match.tsx
+++ b/app/game/post-match.tsx
@@ -30,7 +30,7 @@ import TextField from "../../lib/components/TextField";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 import { CommonActions } from "@react-navigation/native";
 import BodyMedium from "../../lib/components/text/BodyMedium";
-import Heading1Small from "../../lib/components/text/Heading1Small";
+import LabeledDivider from "../../lib/components/LabeledDivider";
 import { colors } from "../../lib/colors";
 import { CustomField } from "../../lib/lovatAPI/getCustomFields";
 import { useTrainingModeStore } from "../../lib/storage/userStores";
@@ -355,7 +355,7 @@ export default function PostMatch() {
           </View>
           {reportState.customFields.length > 0 && (
             <View style={{ gap: 14, marginBottom: 18 }}>
-              <Heading1Small>Asked by your team</Heading1Small>
+              <LabeledDivider label="Asked by your team" />
               {reportState.customFields.map((field) => (
                 <CustomFieldInput
                   key={field.uuid}

--- a/app/game/post-match.tsx
+++ b/app/game/post-match.tsx
@@ -355,10 +355,12 @@ export default function PostMatch() {
           </View>
           {reportState.customFields.length > 0 && (
             <View style={{ gap: 14, marginBottom: 18 }}>
-              {/* Center the divider between the Notes block above (which adds
-                  its own 18px bottom margin on top of the 14px column gap) and
-                  the fields below (14px column gap). */}
-              <View style={{ marginBottom: 18 }}>
+              {/* Keep the divider centered between the Notes block above and
+                  the fields below, with tight equal spacing. Above it there's
+                  the Notes block's 18px bottom margin + the 14px column gap
+                  (32); the negative top margin trims that to match the bottom
+                  (14px column gap + 4px). */}
+              <View style={{ marginTop: -14, marginBottom: 4 }}>
                 <LabeledDivider label="Asked by your team" />
               </View>
               {reportState.customFields.map((field) => (

--- a/app/game/post-match.tsx
+++ b/app/game/post-match.tsx
@@ -30,6 +30,9 @@ import TextField from "../../lib/components/TextField";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 import { CommonActions } from "@react-navigation/native";
 import BodyMedium from "../../lib/components/text/BodyMedium";
+import Heading1Small from "../../lib/components/text/Heading1Small";
+import { colors } from "../../lib/colors";
+import { CustomField } from "../../lib/lovatAPI/getCustomFields";
 import { useTrainingModeStore } from "../../lib/storage/userStores";
 import React from "react";
 import { Checkbox } from "../../lib/components/Checkbox";
@@ -66,6 +69,16 @@ export default function PostMatch() {
 
   const hasOutpostIntakeEvent = reportState.hasOutpostIntakeEvent();
   const autoTraversalTypes = reportState.getAutoTraversalTypes();
+
+  const hasInvalidCustomNumber = reportState.customFields.some((field) => {
+    if (field.type !== "NUMBER") return false;
+    const answer = reportState.customFieldAnswers[field.uuid];
+    return (
+      typeof answer === "string" &&
+      answer.trim() !== "" &&
+      !Number.isFinite(Number(answer.trim()))
+    );
+  });
 
   return (
     <>
@@ -340,13 +353,29 @@ export default function PostMatch() {
               </BodyMedium>
             </View>
           </View>
+          {reportState.customFields.length > 0 && (
+            <View style={{ gap: 14, marginBottom: 18 }}>
+              <Heading1Small>Asked by your team</Heading1Small>
+              {reportState.customFields.map((field) => (
+                <CustomFieldInput
+                  key={field.uuid}
+                  field={field}
+                  value={reportState.customFieldAnswers[field.uuid]}
+                  onChange={(value) =>
+                    reportState.setCustomFieldAnswer(field.uuid, value)
+                  }
+                />
+              ))}
+            </View>
+          )}
           <View style={{ gap: 10 }}>
             <Button
               disabled={
                 trainingModeEnabled ||
                 endgameClimbIsMismatched ||
                 (reportState.hasEventOfType(MatchEventType.StartScoring) &&
-                  reportState.accuracy === null)
+                  reportState.accuracy === null) ||
+                hasInvalidCustomNumber
               }
               variant="primary"
               onPress={() => {
@@ -481,3 +510,119 @@ function PostMatchSelector<TItem, TOutput = TItem>(
     </View>
   );
 }
+
+type CustomFieldInputProps = {
+  field: CustomField;
+  value: string | string[] | undefined;
+  onChange: (value: string | string[] | null) => void;
+};
+
+const CustomFieldInput = ({
+  field,
+  value,
+  onChange,
+}: CustomFieldInputProps) => {
+  switch (field.type) {
+    case "TEXT": {
+      const text = typeof value === "string" ? value : "";
+      return (
+        <View style={{ gap: 7 }}>
+          <LabelSmall>{field.name}</LabelSmall>
+          <TextField
+            value={text}
+            onChangeText={(newText) =>
+              onChange(newText === "" ? null : newText)
+            }
+            multiline={true}
+            returnKeyType="done"
+          />
+        </View>
+      );
+    }
+    case "NUMBER": {
+      const text = typeof value === "string" ? value : "";
+      const invalid =
+        text.trim() !== "" && !Number.isFinite(Number(text.trim()));
+      return (
+        <View style={{ gap: 7 }}>
+          <LabelSmall>{field.name}</LabelSmall>
+          <TextField
+            value={text}
+            onChangeText={(newText) =>
+              onChange(newText === "" ? null : newText)
+            }
+            keyboardType="decimal-pad"
+            error={invalid}
+          />
+          {invalid && (
+            <BodyMedium color={colors.danger.default}>
+              Enter a number
+            </BodyMedium>
+          )}
+        </View>
+      );
+    }
+    case "SINGLE_SELECT": {
+      const selectedOption = typeof value === "string" ? value : null;
+      return (
+        <CustomFieldSelector
+          title={field.name}
+          options={field.options}
+          selected={selectedOption}
+          onChange={(option) =>
+            onChange(option === selectedOption ? null : option)
+          }
+        />
+      );
+    }
+    case "MULTI_SELECT": {
+      const selectedOptions = Array.isArray(value) ? value : [];
+      return (
+        <CustomFieldSelector
+          title={field.name}
+          options={field.options}
+          selected={selectedOptions}
+          onChange={(option) => {
+            const newSelected = selectedOptions.includes(option)
+              ? selectedOptions.filter((o) => o !== option)
+              : [...selectedOptions, option];
+            onChange(newSelected.length === 0 ? null : newSelected);
+          }}
+          multiSelect
+        />
+      );
+    }
+  }
+};
+
+// PostMatchSelector's typing doesn't allow a nullable plain-string selection,
+// so this variant renders the same visuals for custom select fields.
+const CustomFieldSelector = ({
+  title,
+  options,
+  selected,
+  onChange,
+  multiSelect = false,
+}: {
+  title: string;
+  options: string[];
+  selected: string | string[] | null;
+  onChange: (option: string) => void;
+  multiSelect?: boolean;
+}) => {
+  return (
+    <View style={{ gap: 7 }}>
+      <LabelSmall>{title}</LabelSmall>
+      <Picker
+        style="inset-picker"
+        options={options.map((option) => ({
+          label: option,
+          value: option,
+        }))}
+        selected={selected ?? []}
+        onChange={onChange}
+        multiSelect={multiSelect}
+      />
+    </View>
+  );
+};

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -18,6 +18,7 @@ import { IconButton } from "../lib/components/IconButton";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import {
   getServiceLoader,
+  useCustomFieldsStore,
   useServiceErrorStore,
   useServicesLoadingStore,
   useTeamScoutersStore,
@@ -559,6 +560,7 @@ const ServiceStatus = () => {
     useTeamScoutersStore.getState(),
     useScouterScheduleStore.getState(),
     useTournamentsStore.getState(),
+    useCustomFieldsStore.getState(),
   ];
 
   const serviceCacheTimes = servicesCached.map((item) => item.timestamp);

--- a/lib/collection/ReportState.ts
+++ b/lib/collection/ReportState.ts
@@ -14,6 +14,7 @@ import { Beached } from "./Beached";
 import { DefenseEffectiveness } from "./DefenseEffectiveness";
 import { ScoresWhileMoving } from "./ScoresWhileMoving";
 import { EndgameClimb } from "./EndgameClimb";
+import { CustomField } from "../lovatAPI/getCustomFields";
 
 export enum GamePhase {
   Auto,
@@ -47,6 +48,10 @@ export type ReportState = {
   driverAbility: DriverAbility;
   notes: string;
 
+  // Custom fields (snapshot taken when the match starts scouting)
+  customFields: CustomField[];
+  customFieldAnswers: Record<string, string | string[]>;
+
   // Actions
   scoutMatch: (meta: ScoutReportMeta) => void;
   restartMatch: () => void;
@@ -67,6 +72,7 @@ export type ReportState = {
   setClimbResult: (value: EndgameClimb) => void;
   setDriverAbility: (value: DriverAbility) => void;
   setNotes: (value: string) => void;
+  setCustomFieldAnswer: (uuid: string, value: string | string[] | null) => void;
 
   stopClimbing: () => void;
   hasEventOfType: (...types: MatchEventType[]) => boolean;

--- a/lib/collection/ScoutReport.ts
+++ b/lib/collection/ScoutReport.ts
@@ -62,6 +62,14 @@ export const scoutReportSchema = z.object({
   driverAbility: z.number(),
   scouterUuid: z.string(),
   events: z.array(scoutReportEventSchema),
+  customFieldAnswers: z
+    .array(
+      z.object({
+        fieldUuid: z.string(),
+        value: z.union([z.string(), z.number(), z.array(z.string())]),
+      }),
+    )
+    .optional(),
 });
 
 export type ScoutReport = z.infer<typeof scoutReportSchema>;

--- a/lib/collection/reportStateStore.ts
+++ b/lib/collection/reportStateStore.ts
@@ -21,6 +21,8 @@ import { ScoresWhileMoving } from "./ScoresWhileMoving";
 import { EndgameClimb } from "./EndgameClimb";
 import { MatchEventType } from "./MatchEventType";
 import Constants from "expo-constants";
+import { CustomField } from "../lovatAPI/getCustomFields";
+import { useCustomFieldsStore } from "../services";
 
 const initialState = {
   events: [],
@@ -39,10 +41,14 @@ const initialState = {
   climbResult: EndgameClimb.NotAttempted,
   driverAbility: DriverAbility.Average,
   notes: "",
+  customFieldAnswers: {} as Record<string, string | string[]>,
 };
 
 export const useReportStateStore = create<ReportState>((set, get) => ({
   ...initialState,
+
+  // Not in initialState so the snapshot survives restartMatch
+  customFields: [] as CustomField[],
 
   scoutMatch: (meta) =>
     set(() => ({
@@ -50,6 +56,7 @@ export const useReportStateStore = create<ReportState>((set, get) => ({
       meta: meta!,
       startPosition: undefined,
       uuid: v4(),
+      customFields: useCustomFieldsStore.getState().data?.data ?? [],
     })),
   restartMatch: () =>
     set(() => ({
@@ -75,6 +82,16 @@ export const useReportStateStore = create<ReportState>((set, get) => ({
   setClimbResult: (value) => set({ climbResult: value }),
   setDriverAbility: (value) => set({ driverAbility: value }),
   setNotes: (value) => set({ notes: value }),
+  setCustomFieldAnswer: (uuid, value) =>
+    set((state) => {
+      const customFieldAnswers = { ...state.customFieldAnswers };
+      if (value === null) {
+        delete customFieldAnswers[uuid];
+      } else {
+        customFieldAnswers[uuid] = value;
+      }
+      return { customFieldAnswers };
+    }),
 
   hasEventOfType: (...types: MatchEventType[]) => {
     const reportState = get();
@@ -341,6 +358,45 @@ export const useReportStateStore = create<ReportState>((set, get) => ({
         }
       };
 
+      // Convert custom field answers to the wire shape, dropping
+      // unanswered or invalid ones
+      const customFieldAnswers = reportState.customFields.flatMap(
+        (field): { fieldUuid: string; value: string | number | string[] }[] => {
+          const answer = reportState.customFieldAnswers[field.uuid];
+          if (answer === undefined) return [];
+
+          switch (field.type) {
+            case "TEXT": {
+              if (typeof answer !== "string") return [];
+              const trimmed = answer.trim();
+              if (trimmed === "") return [];
+              return [{ fieldUuid: field.uuid, value: trimmed }];
+            }
+            case "NUMBER": {
+              if (typeof answer !== "string") return [];
+              const trimmed = answer.trim();
+              if (trimmed === "") return [];
+              const parsed = Number(trimmed);
+              if (!Number.isFinite(parsed)) return [];
+              return [{ fieldUuid: field.uuid, value: parsed }];
+            }
+            case "SINGLE_SELECT": {
+              if (typeof answer !== "string") return [];
+              if (!field.options.includes(answer)) return [];
+              return [{ fieldUuid: field.uuid, value: answer }];
+            }
+            case "MULTI_SELECT": {
+              if (!Array.isArray(answer)) return [];
+              const selections = answer.filter((option) =>
+                field.options.includes(option),
+              );
+              if (selections.length === 0) return [];
+              return [{ fieldUuid: field.uuid, value: selections }];
+            }
+          }
+        },
+      );
+
       const out = {
         appVersion: Constants.expoConfig?.version,
         uuid: reportState.uuid,
@@ -399,6 +455,7 @@ export const useReportStateStore = create<ReportState>((set, get) => ({
             return baseEvent;
           }),
         ],
+        ...(customFieldAnswers.length > 0 ? { customFieldAnswers } : {}),
       };
       return out;
     }
@@ -410,6 +467,7 @@ export const useReportStateStore = create<ReportState>((set, get) => ({
       meta: undefined,
       startTimestamp: undefined,
       startPosition: undefined,
+      customFields: [],
       ...initialState,
     }),
 }));

--- a/lib/components/LabeledDivider.tsx
+++ b/lib/components/LabeledDivider.tsx
@@ -24,8 +24,9 @@ const styles = StyleSheet.create({
   },
   line: {
     flex: 1,
-    height: StyleSheet.hairlineWidth,
-    backgroundColor: colors.gray.hover,
+    // Matches the 2px dividers used elsewhere in Lovat (e.g. the NavBar).
+    height: 2,
+    backgroundColor: colors.gray.default,
   },
   label: {
     color: colors.body.default,

--- a/lib/components/LabeledDivider.tsx
+++ b/lib/components/LabeledDivider.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, View } from "react-native";
+import { colors } from "../colors";
+import BodyMedium from "./text/BodyMedium";
+
+/**
+ * A horizontal rule with a break in the middle for a small, centered label —
+ * e.g. "Asked by your team". Muted gray hairlines flank the text.
+ */
+export default function LabeledDivider({ label }: { label: string }) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.line} />
+      <BodyMedium style={styles.label}>{label}</BodyMedium>
+      <View style={styles.line} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  line: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.gray.hover,
+  },
+  label: {
+    color: colors.body.default,
+  },
+});

--- a/lib/components/Picker.tsx
+++ b/lib/components/Picker.tsx
@@ -96,14 +96,17 @@ export function Picker<T = string>(props: PickerProps<T>) {
               }}
               style={{
                 paddingHorizontal: contained ? 14 : 0,
-                paddingTop: contained ? (i === 0 ? 14 : compact ? 6 : 8) : 8,
+                // Uncontained: uniform 5px top/bottom puts a 10px gap between
+                // the 24px selection indicators. No leading/trailing overrides
+                // are needed without a container to hug.
+                paddingTop: contained ? (i === 0 ? 14 : compact ? 6 : 8) : 5,
                 paddingBottom: contained
                   ? i === options.length - 1
                     ? 14
                     : compact
                       ? 6
                       : 8
-                  : 8,
+                  : 5,
               }}
             >
               <View

--- a/lib/components/Picker.tsx
+++ b/lib/components/Picker.tsx
@@ -59,6 +59,9 @@ export function Picker<T = string>(props: PickerProps<T>) {
         }}
       >
         {options.map((option, i) => {
+          // Options without a description render as a single compact,
+          // vertically-centered row so the label lines up with the indicator.
+          const compact = !option.description;
           return (
             <Button
               key={option.key ?? option.value}
@@ -78,14 +81,15 @@ export function Picker<T = string>(props: PickerProps<T>) {
               }}
               style={{
                 paddingHorizontal: 14,
-                paddingTop: i === 0 ? 14 : 8,
-                paddingBlock: i === options.length - 1 ? 14 : 8,
+                paddingTop: i === 0 ? 14 : compact ? 6 : 8,
+                paddingBottom: i === options.length - 1 ? 14 : compact ? 6 : 8,
               }}
             >
               <View
                 style={{
                   flexDirection: "row",
                   gap: 12,
+                  alignItems: compact ? "center" : "flex-start",
                 }}
               >
                 <SelectionIndicator
@@ -103,15 +107,17 @@ export function Picker<T = string>(props: PickerProps<T>) {
                   >
                     {option.label}
                   </LabelSmall>
-                  <BodyMedium
-                    style={{
-                      color: option.disabled
-                        ? colors.gray.hover
-                        : colors.body.default,
-                    }}
-                  >
-                    {option.description}
-                  </BodyMedium>
+                  {option.description ? (
+                    <BodyMedium
+                      style={{
+                        color: option.disabled
+                          ? colors.gray.hover
+                          : colors.body.default,
+                      }}
+                    >
+                      {option.description}
+                    </BodyMedium>
+                  ) : null}
                 </View>
               </View>
             </Button>

--- a/lib/components/Picker.tsx
+++ b/lib/components/Picker.tsx
@@ -27,6 +27,12 @@ type PickerProps<T> = {
   onChange: (value: T) => void;
   multiSelect?: boolean;
   style?: PickerStyle;
+  /**
+   * inset-picker only: when false, drops the filled row containers and their
+   * horizontal padding, rendering bare selection rows. Useful when options
+   * have no descriptions and the filled container feels too heavy.
+   */
+  contained?: boolean;
 };
 
 export type PickerStyle =
@@ -41,6 +47,7 @@ export function Picker<T = string>(props: PickerProps<T>) {
     onChange,
     multiSelect = false,
     style = "horizontal-group",
+    contained = true,
   } = props;
 
   const isSelected = (value: T) => {
@@ -54,7 +61,7 @@ export function Picker<T = string>(props: PickerProps<T>) {
     return (
       <View
         style={{
-          borderRadius: 7,
+          borderRadius: contained ? 7 : 0,
           overflow: "hidden",
         }}
       >
@@ -65,11 +72,19 @@ export function Picker<T = string>(props: PickerProps<T>) {
           return (
             <Button
               key={option.key ?? option.value}
-              backgroundColorSet={{
-                default: colors.secondaryContainer.default,
-                hover: colors.gray.default,
-                faded: colors.secondaryContainer.default,
-              }}
+              backgroundColorSet={
+                contained
+                  ? {
+                      default: colors.secondaryContainer.default,
+                      hover: colors.gray.default,
+                      faded: colors.secondaryContainer.default,
+                    }
+                  : {
+                      default: "transparent",
+                      hover: colors.secondaryContainer.default,
+                      faded: "transparent",
+                    }
+              }
               borderRadius={0}
               disabled={option.disabled}
               onPress={() => {
@@ -80,9 +95,15 @@ export function Picker<T = string>(props: PickerProps<T>) {
                 onChange(option.value);
               }}
               style={{
-                paddingHorizontal: 14,
-                paddingTop: i === 0 ? 14 : compact ? 6 : 8,
-                paddingBottom: i === options.length - 1 ? 14 : compact ? 6 : 8,
+                paddingHorizontal: contained ? 14 : 0,
+                paddingTop: contained ? (i === 0 ? 14 : compact ? 6 : 8) : 8,
+                paddingBottom: contained
+                  ? i === options.length - 1
+                    ? 14
+                    : compact
+                      ? 6
+                      : 8
+                  : 8,
               }}
             >
               <View

--- a/lib/components/Picker.tsx
+++ b/lib/components/Picker.tsx
@@ -80,8 +80,10 @@ export function Picker<T = string>(props: PickerProps<T>) {
                       faded: colors.secondaryContainer.default,
                     }
                   : {
+                      // No container to highlight, so keep rows transparent on
+                      // press too — haptics and the indicator convey the tap.
                       default: "transparent",
-                      hover: colors.secondaryContainer.default,
+                      hover: "transparent",
                       faded: "transparent",
                     }
               }

--- a/lib/components/Picker.tsx
+++ b/lib/components/Picker.tsx
@@ -114,7 +114,9 @@ export function Picker<T = string>(props: PickerProps<T>) {
               <View
                 style={{
                   flexDirection: "row",
-                  gap: 12,
+                  // Uncontained rows match the labeled Checkbox (e.g. "Robot
+                  // broke"): 10px indicator-to-label gap, centered.
+                  gap: contained ? 12 : 10,
                   alignItems: compact ? "center" : "flex-start",
                 }}
               >
@@ -128,7 +130,9 @@ export function Picker<T = string>(props: PickerProps<T>) {
                     color={
                       option.disabled
                         ? colors.gray.hover
-                        : colors.onBackground.default
+                        : contained
+                          ? colors.onBackground.default
+                          : colors.body.default
                     }
                   >
                     {option.label}

--- a/lib/lovatAPI/getCustomFields.ts
+++ b/lib/lovatAPI/getCustomFields.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { get } from "./lovatAPI";
+
+export const customFieldTypeSchema = z.enum([
+  "TEXT",
+  "NUMBER",
+  "SINGLE_SELECT",
+  "MULTI_SELECT",
+]);
+
+export type CustomFieldType = z.infer<typeof customFieldTypeSchema>;
+
+export const customFieldSchema = z.object({
+  uuid: z.string(),
+  name: z.string(),
+  type: customFieldTypeSchema,
+  options: z.array(z.string()),
+});
+
+export type CustomField = z.infer<typeof customFieldSchema>;
+
+const customFieldsManifestSchema = z.object({
+  hash: z.string(),
+  data: z.array(customFieldSchema),
+});
+
+export type CustomFieldsManifest = z.infer<typeof customFieldsManifestSchema>;
+
+export const getCustomFields = async (): Promise<CustomFieldsManifest> => {
+  const response = await get("/v1/manager/customfields/manifest");
+
+  if (response.status === 404) {
+    // Older servers don't have custom fields; treat the feature as absent
+    return { hash: "", data: [] };
+  }
+
+  if (!response.ok) {
+    throw new Error("Error fetching custom fields");
+  }
+
+  return customFieldsManifestSchema.parse(await response.json());
+};

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -8,12 +8,17 @@ import {
 import { Scouter } from "./models/scouter";
 import { getTeamScouters } from "./lovatAPI/getTeamScouters";
 import { getTournaments, Tournament } from "./lovatAPI/getTournaments";
+import {
+  CustomFieldsManifest,
+  getCustomFields,
+} from "./lovatAPI/getCustomFields";
 
 export function getServiceLoader() {
   const fetchScouterSchedule =
     useScouterScheduleStore.getInitialState().fetchData;
   const fetchTeamScouters = useTeamScoutersStore.getInitialState().fetchData;
   const fetchTournaments = useTournamentsStore.getInitialState().fetchData;
+  const fetchCustomFields = useCustomFieldsStore.getInitialState().fetchData;
   const setServicesLoading = useServicesLoadingStore.getInitialState().setValue;
   const setServiceError = useServiceErrorStore.getInitialState().setValue;
 
@@ -24,6 +29,7 @@ export function getServiceLoader() {
       await fetchTournaments();
       await fetchTeamScouters();
       await fetchScouterSchedule();
+      await fetchCustomFields();
     } catch (e) {
       console.error(e);
       error = JSON.stringify(e);
@@ -92,3 +98,9 @@ export const useTournamentsStore = createGenericServiceStore<Tournament[]>(
   getTournaments,
   "tournamentsListStore",
 );
+
+export const useCustomFieldsStore =
+  createGenericServiceStore<CustomFieldsManifest>(
+    getCustomFields,
+    "customFieldsStore",
+  );


### PR DESCRIPTION
Adds custom fields to the collection app: scouting leads' custom questions appear in an **"Asked by your team"** section at the bottom of the post-match screen and are submitted with the scout report.

## What's here
- **New `getCustomFields` fetcher** hitting the team-scoped manifest endpoint (`/v1/manager/customfields/manifest`); treats a 404 as "feature absent → no fields".
- **New offline-cached custom-fields service** (`createGenericServiceStore`), fetched in the service loader and reflected in the home status pill.
- **Snapshotting**: field definitions are captured into the report at match start, so a mid-match manifest refresh can't desync the form.
- **`customFieldAnswers`** added to report state, `exportScoutReport()`, and the Zod payload — flows to both the direct-upload and QR paths automatically. Unanswered fields are omitted (QR size).
- **Post-match UI**: an "Asked by your team" section, hidden entirely when the team has no fields. Text → multiline input, Number → validated numeric input, Single/Multi select → the existing inset picker. All optional.

No `scoutReportMigrations` entry needed (the payload change is additive/optional).

## Testing
Drove the full match flow on an iOS simulator against a local server: the section renders all four field types, answers submit through the real upload path, and the values land in the DB exactly (number/single/multi correct, blank text omitted). `ts:check`, `lint`, `format:check` clean.


---

**Related PRs** — this feature spans four repos:
- lovat-server: https://github.com/HighlanderRobotics/lovat-server/pull/54
- lovat-collection: https://github.com/HighlanderRobotics/lovat-collection/pull/85
- Lovat Dashboard: https://github.com/HighlanderRobotics/scouting_dashboard_app/pull/130
- lovat-learn: https://github.com/MangoSwirl/lovat-learn/pull/15
